### PR TITLE
fix wrong use of short terniary operater in databsse uri initialisation

### DIFF
--- a/Migrate/Command/AbstractEnvCommand.php
+++ b/Migrate/Command/AbstractEnvCommand.php
@@ -80,9 +80,9 @@ class AbstractEnvCommand extends AbstractComand
         if ($driver == 'sqlite') {
             $uri .= ":$dbname";
         }  else {
-            $uri .= ($dbname == null) ?: ":dbname=$dbname";
-            $uri .= ($host == null) ?: ";host=$host";
-            $uri .= ($port == null) ?: ";port=$port";
+            $uri .= ($dbname == null) ? '' : ":dbname=$dbname";
+            $uri .= ($host == null) ? '' : ";host=$host";
+            $uri .= ($port == null) ? '' : ";port=$port";
         }
         $this->db = new \PDO(
             $uri,


### PR DESCRIPTION
With a env-file like the following (which has been initialized by the setup):
````
connection:
    host:     ~
    driver:   mysql
    port:     ~
    username: composer_exp
    password: composer_exp
    database: composer_exp

changelog: changelog
default_editor: nano
````

The uri-Construction code Builds the URI as `mysql:dbname=composer_exp11` which is obviously wrong.

The Reason for this is, that the in short-form terniary operator `$uri .= ($host == null) ?: ";host=$host";` the test `$host == null` succeeds and returns `True`. When the first half of the short-form terniary operater returns a truthy value, this value is returned and the second half is not evaluated.

Thus, the Value `True` will be concatanated to the string, resulting in the extra `1` being appended to the Uri.
