### PR TITLE
Add environment annotation to SQL

### DIFF
--- a/Migrate/Command/AbstractEnvCommand.php
+++ b/Migrate/Command/AbstractEnvCommand.php
@@ -325,8 +325,6 @@ class AbstractEnvCommand extends AbstractCommand
     {
         $allowed = $migration->getAllowedEnvironments();
 
-        print_r([$this->environment, $allowed]);
-
         return in_array(strtoupper($this->environment), $allowed) || in_array('ANY', $allowed);
     }
 }

--- a/Migrate/Command/AbstractEnvCommand.php
+++ b/Migrate/Command/AbstractEnvCommand.php
@@ -30,6 +30,11 @@ class AbstractEnvCommand extends AbstractCommand
     private $config;
 
     /**
+     * @var string
+     */
+    private $environment;
+
+    /**
      * @return \PDO
      */
     public function getDb()
@@ -65,6 +70,8 @@ class AbstractEnvCommand extends AbstractCommand
         if ($env === null) {
             $env = $input->getArgument('env');
         }
+
+        $this->environment = $env;
 
         $parser = $configLocator->locate($env);
 
@@ -212,7 +219,7 @@ class AbstractEnvCommand extends AbstractCommand
     {
         $this->getDb()->beginTransaction();
 
-        if ($changeLogOnly === false) {
+        if ($changeLogOnly === false && $this->isEnvironmentAllowed($migration)) {
             $result = $this->getDb()->exec($migration->getSqlUp());
 
             if ($result === false) {
@@ -244,7 +251,7 @@ class AbstractEnvCommand extends AbstractCommand
     {
         $this->getDb()->beginTransaction();
 
-        if ($changeLogOnly === false) {
+        if ($changeLogOnly === false && $this->isEnvironmentAllowed($migration)) {
             $result = $this->getDb()->exec($migration->getSqlDown());
 
             if ($result === false) {
@@ -312,5 +319,14 @@ class AbstractEnvCommand extends AbstractCommand
         }
 
         return $toExecute;
+    }
+
+    protected function isEnvironmentAllowed(Migration $migration)
+    {
+        $allowed = $migration->getAllowedEnvironments();
+
+        print_r([$this->environment, $allowed]);
+
+        return in_array(strtoupper($this->environment), $allowed) || in_array('ANY', $allowed);
     }
 }

--- a/README.md
+++ b/README.md
@@ -95,11 +95,15 @@ $ ./bin/migrate migrate:create
 Migrations file are like this
 
     -- // add table users
+    -- @ENVIRONMENTS [DEV,QA]
     -- Migration SQL that makes the change goes here.
     create table users (id integer, name text);
     -- @UNDO
     -- SQL to undo the change goes here.
     drop table users;
+
+You can restrict which environment uses this SQL with "@ENVIRONMENT" annotation. Values inside array brackets can be
+one or more comma separated environment values OR "ANY" 
 
 List migrations
 ------------------

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
   "config": {
     "bin-dir": "bin"
   },
+  "scripts": {
+      "phpcs": "bin/phpcs --standard=PSR2 Migrate/"
+  },
   "autoload": {
     "psr-4": {
       "Migrate\\": "Migrate/"

--- a/templates/migration.tpl
+++ b/templates/migration.tpl
@@ -1,4 +1,5 @@
 -- // {DESCRIPTION}
+-- @ENVIRONMENTS [{ENVIRONMENTS}]
 -- Migration SQL that makes the change goes here.
 
 -- @UNDO

--- a/tests/Command/CreateCommandTest.php
+++ b/tests/Command/CreateCommandTest.php
@@ -42,6 +42,8 @@ class CreateCommandTest extends AbstractCommandTester
         /* @var $question QuestionHelper */
         $question = $command->getHelper('question');
         $question->setInputStream(InputStreamUtil::type("je suis une super migration &&&ééé\n\n:x\n"));
+        $question = $command->getHelper('question');
+        $question->setInputStream(InputStreamUtil::type("testing\n\n:x\n"));
 
         $commandTester->execute(array('command' => $command->getName()));
 
@@ -53,7 +55,7 @@ class CreateCommandTest extends AbstractCommandTester
         $this->assertFileExists($fileName);
         $content = file_get_contents($fileName);
         $expected =<<<EXPECTED
--- // je suis une super migration &&&ééé\n-- Migration SQL that makes the change goes here.\n\n-- @UNDO\n-- SQL to undo the change goes here.\n
+-- // je suis une super migration &&&ééé\n-- @ENVIRONMENTS [TESTING]\n-- Migration SQL that makes the change goes here.\n\n-- @UNDO\n-- SQL to undo the change goes here.\n
 EXPECTED;
 
         $this->assertEquals($expected, $content);

--- a/tests/Command/CreateCommandTest.php
+++ b/tests/Command/CreateCommandTest.php
@@ -42,8 +42,6 @@ class CreateCommandTest extends AbstractCommandTester
         /* @var $question QuestionHelper */
         $question = $command->getHelper('question');
         $question->setInputStream(InputStreamUtil::type("je suis une super migration &&&ééé\n\n:x\n"));
-        $question = $command->getHelper('question');
-        $question->setInputStream(InputStreamUtil::type("testing\n\n:x\n"));
 
         $commandTester->execute(array('command' => $command->getName()));
 
@@ -55,7 +53,7 @@ class CreateCommandTest extends AbstractCommandTester
         $this->assertFileExists($fileName);
         $content = file_get_contents($fileName);
         $expected =<<<EXPECTED
--- // je suis une super migration &&&ééé\n-- @ENVIRONMENTS [TESTING]\n-- Migration SQL that makes the change goes here.\n\n-- @UNDO\n-- SQL to undo the change goes here.\n
+-- // je suis une super migration &&&ééé\n-- @ENVIRONMENTS [ANY]\n-- Migration SQL that makes the change goes here.\n\n-- @UNDO\n-- SQL to undo the change goes here.\n
 EXPECTED;
 
         $this->assertEquals($expected, $content);


### PR DESCRIPTION
This change allows filtering migrations for specific environments. This is useful for mock data in dev/qa, environment specific settings, etc.

Signed-off-by: five07 <mstclaire@five07.com>